### PR TITLE
Collapse two if statements in AttoTransaction.isValid() into one

### DIFF
--- a/commons-core/src/commonMain/kotlin/cash/atto/commons/AttoTransaction.kt
+++ b/commons-core/src/commonMain/kotlin/cash/atto/commons/AttoTransaction.kt
@@ -52,11 +52,7 @@ data class AttoTransaction(
             return false
         }
 
-        if (block is PreviousSupport && !work.isValid(block)) {
-            return false
-        }
-
-        if (block is AttoOpenBlock && !work.isValid(block)) {
+        if (!work.isValid(block)) {
             return false
         }
 


### PR DESCRIPTION
In commit https://github.com/attocash/commons/commit/289bd6703b06432a9e61a72dc0d920481b646819, two overloads of AttoWork.isValid(...) were combined into one that accepts an AttoBlock. That removed the need for having two if statements here.

Edit: atto://ad7z3jdoeqwayzpaiafizb5su6zc2fyvbeg2wq5t3yfj3q5iuprx23z437juk

(I hope the workflows aren't failing because of this change? I didn't properly test it)